### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v 2.0.0
+
+API changes:
+1. change macro names to `macro-start`, `macro-stop`, `macro-save`, more easy to remember.
+2. Remove highline dependency, don't ask macro name when run `macro-stop`, instead, need provide macro name when run `macro-start`
+3. `macro-save` save macro to ~/.pry-macro instead of ~/.pryrc, still will autoload all macros too.
+4. when recording macro, will skip `edit` command, this will permit you use your favorited editor to edit macro!
+
+Bugfix:
+1. Fix for work with newest Pry.
+
 ## v 1.0.1 - Bug fix
 
 Removed dependency on pry-plus
@@ -31,4 +42,3 @@ Added options
 ## v 0.0.1
 
 Initial release
-

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
 Copyright (c) 2014 Brandon Weaver
+Copyright (c) 2019 Billy Zheng
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PryMacro
 
+2.0 is released!, please see [CHANGELOG](https://github.com/zw963/pry-macro)
+
 Record command line actions for replaying.
 
 ## How is this different from play and history?
@@ -9,10 +11,10 @@ later, as well as use pry commands.
 
 ## Basic Usage
 
-Start recording:
+Start recording, you need provide a macro name.
 
 ```ruby
-[1] pry(main)> record-macro
+[1] pry(main)> macro-start testing
 [2] pry(main)> 1
 => 1
 [3] pry(main)> 'foo'
@@ -22,11 +24,10 @@ self.methods: inspect  to_s
 locals: _  __  _dir_  _ex_  _file_  _in_  _out_  _pry_
 ```
 
-Stop the recording and name it:
+Stop the recording:
 
 ```ruby
-[5] pry(main)> stop-macro
-Macro Name: testing
+[5] pry(main)> macro-stop
 ```
 
 Run it like any other command:
@@ -39,15 +40,16 @@ self.methods: inspect  to_s
 locals: _  __  _dir_  _ex_  _file_  _in_  _out_  _pry_
 ```
 
-Like it? You can save it and have it automatically append to your PryRC:
+Like it? You can save it to ~/.pry-macro, and will load automatically when next run pry!
 
 ```ruby
-[10] pry(main)> save-macro testing
+[10] pry(main)> macro-save testing
 ```
 
 ...and here it is, nice and formatted:
 
 ```ruby
+╰─ $ cat ~/.pry-macro
 Pry::Commands.block_command 'testing', 'no description' do
   _pry_.input = StringIO.new(
     <<-MACRO.gsub(/^ {4,6}/, '')
@@ -60,6 +62,8 @@ end
 ```
 
 ## More Advanced Usage
+
+When recording macro, you can run `edit` command in any time to write macro use you favorited editor!
 
 We're working on getting the Wiki up to date to cover more advanced usage.
 

--- a/lib/pry-macro.rb
+++ b/lib/pry-macro.rb
@@ -9,7 +9,7 @@ module PryMacro
 
     def options(opts)
       opts.banner <<-BANNER
-      Usage: #{command_name}111 name [-d desc], [-v]
+      Usage: #{command_name} name [-d desc], [-v]
 
       Starts recording a macro, have to provide a macro name to be execute as command later.
       Descriptions may be provided, but will default to 'no description'.

--- a/lib/pry-macro.rb
+++ b/lib/pry-macro.rb
@@ -8,7 +8,7 @@ module PryMacro
     description 'Starts recording a macro.'
 
     def options(opts)
-      opts.banner <<-BANNER
+      opts.banner <<~BANNER
       Usage: #{command_name} name [-d desc], [-v]
 
       Starts recording a macro, have to provide a macro name to be execute as command later.
@@ -39,7 +39,7 @@ module PryMacro
     description 'Stops recording macro.'
 
     def options(opts)
-      opts.banner <<-BANNER
+      opts.banner <<~BANNER
       Usage: #{command_name}
 
       Stops recording a macro, loads the command, and caches it for later saving if desired.
@@ -48,7 +48,7 @@ module PryMacro
 
     def setup
       if !_pry_.instance_variable_defined?(:@record_stack) && _pry_.record_stack.empty?
-        raise 'Cannot stop macro when macro is not start.'
+        raise 'Cannot stop recording a macro when no macro is recording.'
       end
 
       session_begin = _pry_.record_stack.pop
@@ -72,10 +72,10 @@ module PryMacro
 
       # Save the command into a string, and make it look decent
       # Tinge of a heredocs hack
-      command_string = <<-COMMAND_STRING.gsub(/^ {10}/, '')
+      command_string = <<~COMMAND_STRING
           Pry::Commands.block_command '#{name}', '#{desc}' do
             _pry_.input = StringIO.new(
-              <<-MACRO.gsub(/^ {4,6}/, '')
+              <<-MACRO
                 #{history_lines}
               MACRO
             )
@@ -95,7 +95,7 @@ module PryMacro
     description 'Save cached macro.'
 
     def options(opts)
-      opts.banner <<-BANNER
+      opts.banner <<~BANNER
       Usage: #{command_name} name
 
       Saves a cached macro to your ~/.pry-macro.

--- a/lib/pry-macro.rb
+++ b/lib/pry-macro.rb
@@ -5,11 +5,11 @@ module PryMacro
   MacroString = Struct.new(:name, :command)
 
   Pry::Commands.create_command 'macro-start' do
+    description 'Starts recording a macro.'
+
     def options(opts)
       opts.banner <<-BANNER
-      Starts recording a macro.
-
-      Usage: macro-start name [-d desc], [-v]
+      Usage: #{command_name}111 name [-d desc], [-v]
 
       Starts recording a macro, have to provide a macro name to be execute as command later.
       Descriptions may be provided, but will default to 'no description'.
@@ -36,13 +36,13 @@ module PryMacro
   end
 
   Pry.commands.create_command 'macro-stop' do
+    description 'Stops recording macro.'
+
     def options(opts)
       opts.banner <<-BANNER
-        Stops recording macro.
+      Usage: #{command_name}
 
-        Usage: macro-stop
-
-        Stops recording a macro, loads the command, and caches it for later saving if desired.
+      Stops recording a macro, loads the command, and caches it for later saving if desired.
       BANNER
     end
 
@@ -55,7 +55,7 @@ module PryMacro
       session_end   = Pry.history.session_line_count
 
       # Get the history between the start and end of the recording session
-      session_history = Pry.history.to_a.last(session_end - session_begin)[0..-2].reject! {|e| e == 'edit' }
+      session_history = Pry.history.to_a.last(session_end - session_begin)[0..-2].reject {|e| e == 'edit' }
       @history = session_history.each_with_object(StringIO.new) {|history, io| io.puts(history) }
     end
 
@@ -63,7 +63,6 @@ module PryMacro
       # Have to have a name to execute this later
       opts = _pry_.pry_macro_options
 
-      # ppp opts.arguments.first
       name = opts[:name]
       desc = opts[:desc] || 'no description'
 
@@ -83,7 +82,7 @@ module PryMacro
           end
         COMMAND_STRING
 
-      puts command_string if opts[:verbose]
+      output.puts command_string if opts[:verbose]
 
       # ...so that we can save the contents for saving later (optional)
       _pry_.macro_strings << MacroString.new(name, command_string)
@@ -93,13 +92,13 @@ module PryMacro
   end
 
   Pry.commands.create_command 'macro-save' do
+    description 'Save cached macro.'
+
     def options(opts)
       opts.banner <<-BANNER
-        Save cached macro.
+      Usage: #{command_name} name
 
-        Usage: macro-save name
-
-        Saves a cached macro to your ~/.pry-macro.
+      Saves a cached macro to your ~/.pry-macro.
       BANNER
     end
 

--- a/lib/pry-macro/version.rb
+++ b/lib/pry-macro/version.rb
@@ -1,3 +1,3 @@
 module PryMacro
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/lib/pry-macro/version.rb
+++ b/lib/pry-macro/version.rb
@@ -1,3 +1,3 @@
 module PryMacro
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/lib/pry-macro/version.rb
+++ b/lib/pry-macro/version.rb
@@ -1,3 +1,3 @@
 module PryMacro
-  VERSION = '1.0.1'
+  VERSION = '2.0.0'
 end

--- a/pry-macro.gemspec
+++ b/pry-macro.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "pry-macro"
   spec.version       = PryMacro::VERSION
   spec.authors       = ["Brandon Weaver"]
-  spec.email         = ["keystonelemur@gmail.com"]
+  spec.email         = ["keystonelemur@gmail.com", 'vil963@gmail.com']
   spec.summary       = %q{Macros for Pry}
   spec.description   = %q{Macro Recording and Saving functionality for pry}
   spec.homepage      = "https://github.com/baweaver/pry-macro"
@@ -25,5 +25,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
 
   spec.add_runtime_dependency "pry"
-  spec.add_runtime_dependency 'highline'
 end


### PR DESCRIPTION
API changes:
1. change macro names to `macro-start`, `macro-stop`, `macro-save`, more easy to remember.
2. Remove highline dependency, don't ask macro name when run `macro-stop`, instead, need provide macro name when run `macro-start`
3. `macro-save` save macro to ~/.pry-macro instead of ~/.pryrc, still will autoload all macros too.
4. when recording macro, will skip `edit` command, this will permit you use your favorited editor to edit macro!

Bugfix:
1. Fix for work with newest Pry.